### PR TITLE
Select tag improvements

### DIFF
--- a/lib/sinatra_more/markup_plugin/form_helpers.rb
+++ b/lib/sinatra_more/markup_plugin/form_helpers.rb
@@ -160,11 +160,13 @@ module SinatraMore
     end
 
     # Returns the options tags for a select based on the given option items
-    def options_for_select(option_items, selected_value=nil)
+    def options_for_select(option_items, selected_values=[])
       return '' if option_items.blank?
+      selected_values = [selected_values].compact unless selected_values.is_a?(Array)
       option_items.collect { |caption, value|
         value ||= caption
-        content_tag(:option, caption, :value => value, :selected => selected_value.to_s =~ /#{value}|#{caption}/)
+        selected = selected_values.find {|v| v.to_s =~ /^(#{value}|#{caption})$/}
+        content_tag(:option, caption, :value => value, :selected => !!selected)
       }.join("\n")
     end
 

--- a/test/markup_plugin/test_form_helpers.rb
+++ b/test/markup_plugin/test_form_helpers.rb
@@ -331,6 +331,16 @@ class TestFormHelpers < Test::Unit::TestCase
       assert_has_tag('select option', :content => 'Black', :value => 'black1') { actual_html }
     end
 
+    should "should mark correct options as selected" do
+      options = [['Fun', 'f1'], ['Funny', 'f2'], ['Funniest', 'f3']]
+      actual_html = select_tag(:fun_level, :options => options, :selected => ['Fun', 'Funny'], :multiple => true)
+      assert_has_tag(:select, :name => 'fun_level[]') { actual_html }
+      assert_has_tag('select option', :selected => 'selected', :count => 2) { actual_html}
+      assert_has_tag('select option', :content => 'Fun', :value => 'f1', :selected => 'selected') { actual_html }
+      assert_has_tag('select option', :content => 'Funny', :value => 'f2', :selected => 'selected') { actual_html }
+      assert_has_tag('select option', :content => 'Funniest', :value => 'f3') { actual_html }
+    end
+
     should "display select tag in erb" do
       visit '/erb/form_tag'
       assert_have_selector 'form.simple-form select', :count => 1, :name => 'color'


### PR DESCRIPTION
- Allow selecting multiple values in with select_tag.
- Also, fixed a bug in the select_tag. When select_tag options were "1", "12", "13" and I marked "1" as selected, then "12" and "13" were marked as selected as well.
