### PR TITLE
Remove deprecation warning when invoking Sinatra::Base#options.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec

--- a/lib/sinatra_more/markup_plugin/form_helpers.rb
+++ b/lib/sinatra_more/markup_plugin/form_helpers.rb
@@ -185,7 +185,7 @@ module SinatraMore
     # If explicitly defined, returns that, otherwise returns defaults
     # configured_form_builder_class(nil) => StandardFormBuilder
     def configured_form_builder_class(explicit_builder=nil)
-      default_builder = self.respond_to?(:options) && self.options.default_builder
+      default_builder = self.respond_to?(:settings) && self.settings.default_builder
       configured_builder = explicit_builder || default_builder || 'StandardFormBuilder'
       configured_builder = configured_builder.constantize if configured_builder.is_a?(String)
       configured_builder


### PR DESCRIPTION
Prevent the following Sinatra warn:
  Sinatra::Base#options is deprecated and will be removed, use #settings instead.
